### PR TITLE
fix/ long description in idea roll

### DIFF
--- a/src/components/IdeaRoll.tsx
+++ b/src/components/IdeaRoll.tsx
@@ -128,7 +128,6 @@ const IdeaRollTemplate = (props: {
                             </>
                         }
                     />
-                    <div>{item.dataset.description}</div>
                 </List.Item>
             )}
         />


### PR DESCRIPTION
Advances #45

The dataset description, even very long ones, are rendering on the IdeaRoll.

It's not clear to me that we want the dataset description to render there, until @jessicasyu recently uploaded a new dataset we never had one. So I just removed it for now.
