### PR TITLE
zizmor audit and add zizmor to static checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,19 @@ on:
     branches:
       - main
 
+permissions:
+    contents: read
+
 jobs:
     lint:
         name: ✅ Lint
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+              with:
+                  persist-credentials: false
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: ${{env.NODE_VERSION}}
             - run: yarn install --frozen-lockfile
@@ -26,9 +31,11 @@ jobs:
         name: Format check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+              with:
+                  persist-credentials: false
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: ${{env.NODE_VERSION}}
             - run: yarn install --frozen-lockfile
@@ -37,10 +44,24 @@ jobs:
         name: Test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+              with:
+                  persist-credentials: false
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                   node-version: ${{env.NODE_VERSION}}
             - run: yarn install --frozen-lockfile
             - run: npm test
+    workflow-lint:
+        name: Workflow lint
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            security-events: write
+        steps:
+            - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+              with:
+                  persist-credentials: false
+            - name: Run zizmor 🌈
+              uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/reuse_ci.yml
+++ b/.github/workflows/reuse_ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 jobs:
   call-workflow:
     permissions:

--- a/.github/workflows/reuse_ci.yml
+++ b/.github/workflows/reuse_ci.yml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   call-workflow:
+    permissions:
+      contents: read
     uses: AllenCell/reusable-workflows/.github/workflows/setup_yarn.yml@bdeb8b1fbd7fbe9d364855bb7a365f3c844c5792
-    with: 
+    with:
       node-version: "24.x"
       yarn-version: "1.22.22"


### PR DESCRIPTION
Jumping on the `zizmor` bandwagon after reading about TanStack compromise. Hardening up GH actions with commit hashes and adding a zizmor check to CI.