### PR TITLE
Add image thumbnails to idea list

### DIFF
--- a/src/components/FigureThumbnail.tsx
+++ b/src/components/FigureThumbnail.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
+
+interface FigureThumbnailProps {
+    figure: {
+        url?: string | null;
+        file?: {
+            childImageSharp?: {
+                gatsbyImageData: IGatsbyImageData;
+            } | null;
+        } | null;
+    };
+    className?: string;
+}
+
+const scaleStyle: React.CSSProperties = {
+    transform: "scale(1.2)",
+    transformOrigin: "center",
+};
+
+const imgFillStyle: React.CSSProperties = {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    objectPosition: "center",
+    display: "block",
+    ...scaleStyle,
+};
+
+const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
+    className,
+    figure,
+}) => {
+    const gatsbyImage = figure.file?.childImageSharp
+        ? getImage(figure.file.childImageSharp)
+        : null;
+
+    if (gatsbyImage) {
+        return (
+            <GatsbyImage
+                image={gatsbyImage}
+                alt=""
+                className={className}
+                imgStyle={scaleStyle}
+            />
+        );
+    }
+
+    if (figure.url) {
+        return (
+            <div className={className}>
+                <img src={figure.url} alt="" style={imgFillStyle} />
+            </div>
+        );
+    }
+
+    return null;
+};
+
+export default FigureThumbnail;

--- a/src/components/FigureThumbnail.tsx
+++ b/src/components/FigureThumbnail.tsx
@@ -14,11 +14,13 @@ interface FigureThumbnailProps {
         } | null;
     };
     className?: string;
+    style?: React.CSSProperties;
 }
 
 const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
     className,
     figure,
+    style,
 }) => {
     const gatsbyImage = figure.file?.childImageSharp
         ? getImage(figure.file.childImageSharp)
@@ -31,13 +33,14 @@ const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
                 alt=""
                 className={className}
                 imgClassName={scale}
+                style={style}
             />
         );
     }
 
     if (figure.url) {
         return (
-            <div className={className}>
+            <div className={className} style={style}>
                 <img src={figure.url} alt="" className={imgFill} />
             </div>
         );

--- a/src/components/FigureThumbnail.tsx
+++ b/src/components/FigureThumbnail.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { GatsbyImage, IGatsbyImageData, getImage } from "gatsby-plugin-image";
 
+const { imgFill, scale } = require("../style/figure-thumbnail.module.css");
+
 interface FigureThumbnailProps {
     figure: {
         url?: string | null;
@@ -13,20 +15,6 @@ interface FigureThumbnailProps {
     };
     className?: string;
 }
-
-const scaleStyle: React.CSSProperties = {
-    transform: "scale(1.2)",
-    transformOrigin: "center",
-};
-
-const imgFillStyle: React.CSSProperties = {
-    width: "100%",
-    height: "100%",
-    objectFit: "cover",
-    objectPosition: "center",
-    display: "block",
-    ...scaleStyle,
-};
 
 const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
     className,
@@ -42,7 +30,7 @@ const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
                 image={gatsbyImage}
                 alt=""
                 className={className}
-                imgStyle={scaleStyle}
+                imgClassName={scale}
             />
         );
     }
@@ -50,7 +38,7 @@ const FigureThumbnail: React.FC<FigureThumbnailProps> = ({
     if (figure.url) {
         return (
             <div className={className}>
-                <img src={figure.url} alt="" style={imgFillStyle} />
+                <img src={figure.url} alt="" className={imgFill} />
             </div>
         );
     }

--- a/src/components/IdeaRoll.tsx
+++ b/src/components/IdeaRoll.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Link, graphql, useStaticQuery } from "gatsby";
+import { GatsbyImage, getImage } from "gatsby-plugin-image";
 
 import { TagPopover } from "./TagPopover";
 
@@ -11,6 +12,8 @@ const {
     listItem,
     tagEyebrow,
     tagSeparator,
+    textBlock,
+    thumbnail,
     title,
 } = require("../style/idea-roll.module.css");
 
@@ -40,6 +43,22 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                         type
                         name
                     }
+                    preliminaryFindings {
+                        figures {
+                            type
+                            url
+                            file {
+                                childImageSharp {
+                                    gatsbyImageData(
+                                        width: 80
+                                        height: 64
+                                        layout: FIXED
+                                        quality: 80
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -55,40 +74,75 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
     return (
         <>
             <ul className={container}>
-                {ideas.map((item) => (
-                    <li key={item.id} className={listItem}>
-                        {item.tags.length > 0 && (
-                            <div className={tagEyebrow}>
-                                {item.tags.map((tag, i) => (
-                                    <React.Fragment key={tag}>
-                                        {i > 0 && (
-                                            <span
-                                                className={tagSeparator}
-                                                aria-hidden="true"
-                                            >
-                                                ·
-                                            </span>
-                                        )}
-                                        <TagPopover
-                                            tag={tag}
-                                            currentSlug={item.slug}
-                                            className={eyebrowTag}
-                                        />
-                                    </React.Fragment>
-                                ))}
+                {ideas.map((item) => {
+                    const firstFigure =
+                        item.preliminaryFindings?.figures?.[0] ?? null;
+                    const gatsbyImage = firstFigure?.file?.childImageSharp
+                        ? getImage(firstFigure.file.childImageSharp)
+                        : null;
+
+                    return (
+                        <li key={item.id} className={listItem}>
+                            <div className={textBlock}>
+                                {item.tags.length > 0 && (
+                                    <div className={tagEyebrow}>
+                                        {item.tags.map((tag, i) => (
+                                            <React.Fragment key={tag}>
+                                                {i > 0 && (
+                                                    <span
+                                                        className={tagSeparator}
+                                                        aria-hidden="true"
+                                                    >
+                                                        ·
+                                                    </span>
+                                                )}
+                                                <TagPopover
+                                                    tag={tag}
+                                                    currentSlug={item.slug}
+                                                    className={eyebrowTag}
+                                                />
+                                            </React.Fragment>
+                                        ))}
+                                    </div>
+                                )}
+                                <Link to={item.slug} className={title}>
+                                    {item.title}
+                                </Link>
+                                <div className={byline}>
+                                    by{" "}
+                                    {item.authors
+                                        .map((a) => a.name)
+                                        .join(" · ")}
+                                    {item.dataset
+                                        ? ` — ${item.dataset}`
+                                        : " — No public dataset"}
+                                </div>
                             </div>
-                        )}
-                        <Link to={item.slug} className={title}>
-                            {item.title}
-                        </Link>
-                        <div className={byline}>
-                            by {item.authors.map((a) => a.name).join(" · ")}
-                            {item.dataset
-                                ? ` — ${item.dataset}`
-                                : " — No public dataset"}
-                        </div>
-                    </li>
-                ))}
+
+                            {(gatsbyImage || firstFigure?.url) && (
+                                <Link
+                                    to={item.slug}
+                                    tabIndex={-1}
+                                    aria-hidden="true"
+                                >
+                                    {gatsbyImage ? (
+                                        <GatsbyImage
+                                            image={gatsbyImage}
+                                            alt=""
+                                            className={thumbnail}
+                                        />
+                                    ) : (
+                                        <img
+                                            src={firstFigure!.url!}
+                                            alt=""
+                                            className={thumbnail}
+                                        />
+                                    )}
+                                </Link>
+                            )}
+                        </li>
+                    );
+                })}
             </ul>
             {count !== undefined && (
                 <div>

--- a/src/components/IdeaRoll.tsx
+++ b/src/components/IdeaRoll.tsx
@@ -27,6 +27,8 @@ interface IdeaRollProps {
     count?: number;
 }
 
+const THUMBNAIL_SIZE = { width: 88, height: 56 };
+
 const IdeaRoll = ({ count }: IdeaRollProps) => {
     const queryData = useStaticQuery(graphql`
         query IdeaRoll {
@@ -123,6 +125,10 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                                     aria-hidden="true"
                                 >
                                     <FigureThumbnail
+                                        style={{
+                                            width: THUMBNAIL_SIZE.width,
+                                            height: THUMBNAIL_SIZE.height,
+                                        }}
                                         figure={firstFigure}
                                         className={thumbnail}
                                     />

--- a/src/components/IdeaRoll.tsx
+++ b/src/components/IdeaRoll.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 
 import { Link, graphql, useStaticQuery } from "gatsby";
-import { GatsbyImage, getImage } from "gatsby-plugin-image";
 
+import FigureThumbnail from "./FigureThumbnail";
 import { TagPopover } from "./TagPopover";
 
 const {
@@ -77,9 +77,6 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                 {ideas.map((item) => {
                     const firstFigure =
                         item.preliminaryFindings?.figures?.[0] ?? null;
-                    const gatsbyImage = firstFigure?.file?.childImageSharp
-                        ? getImage(firstFigure.file.childImageSharp)
-                        : null;
 
                     return (
                         <li key={item.id} className={listItem}>
@@ -119,39 +116,16 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                                 </div>
                             </div>
 
-                            {(gatsbyImage || firstFigure?.url) && (
+                            {firstFigure && (
                                 <Link
                                     to={item.slug}
                                     tabIndex={-1}
                                     aria-hidden="true"
                                 >
-                                    {gatsbyImage ? (
-                                        <GatsbyImage
-                                            image={gatsbyImage}
-                                            alt=""
-                                            className={thumbnail}
-                                            imgStyle={{
-                                                transform: "scale(1.2)",
-                                                transformOrigin: "center",
-                                            }}
-                                        />
-                                    ) : (
-                                        <div className={thumbnail}>
-                                            <img
-                                                src={firstFigure!.url!}
-                                                alt=""
-                                                style={{
-                                                    width: "100%",
-                                                    height: "100%",
-                                                    objectFit: "cover",
-                                                    objectPosition: "center",
-                                                    transform: "scale(1.2)",
-                                                    transformOrigin: "center",
-                                                    display: "block",
-                                                }}
-                                            />
-                                        </div>
-                                    )}
+                                    <FigureThumbnail
+                                        figure={firstFigure}
+                                        className={thumbnail}
+                                    />
                                 </Link>
                             )}
                         </li>

--- a/src/components/IdeaRoll.tsx
+++ b/src/components/IdeaRoll.tsx
@@ -50,8 +50,8 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                             file {
                                 childImageSharp {
                                     gatsbyImageData(
-                                        width: 80
-                                        height: 64
+                                        width: 88
+                                        height: 56
                                         layout: FIXED
                                         quality: 80
                                     )
@@ -130,13 +130,27 @@ const IdeaRoll = ({ count }: IdeaRollProps) => {
                                             image={gatsbyImage}
                                             alt=""
                                             className={thumbnail}
+                                            imgStyle={{
+                                                transform: "scale(1.2)",
+                                                transformOrigin: "center",
+                                            }}
                                         />
                                     ) : (
-                                        <img
-                                            src={firstFigure!.url!}
-                                            alt=""
-                                            className={thumbnail}
-                                        />
+                                        <div className={thumbnail}>
+                                            <img
+                                                src={firstFigure!.url!}
+                                                alt=""
+                                                style={{
+                                                    width: "100%",
+                                                    height: "100%",
+                                                    objectFit: "cover",
+                                                    objectPosition: "center",
+                                                    transform: "scale(1.2)",
+                                                    transformOrigin: "center",
+                                                    display: "block",
+                                                }}
+                                            />
+                                        </div>
                                     )}
                                 </Link>
                             )}

--- a/src/style/colors.css
+++ b/src/style/colors.css
@@ -42,6 +42,7 @@
     --main-card-header-color: var(--primary-color);
     --callout-box-bg-color: var(--PAGE_2);
     --callout-box-border-color: var(--ALLEN_ORANGE);
+    --thumbnail-border-color: var(--ALLEN_ORANGE);
 
     /* Layout */
     --content-max-width: 1200px;

--- a/src/style/figure-thumbnail.module.css
+++ b/src/style/figure-thumbnail.module.css
@@ -1,0 +1,14 @@
+.scale {
+    transform: scale(1.2);
+    transform-origin: center;
+}
+
+.imgFill {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+    transform: scale(1.2);
+    transform-origin: center;
+}

--- a/src/style/idea-roll.module.css
+++ b/src/style/idea-roll.module.css
@@ -8,10 +8,18 @@
 .listItem {
     padding: 22px 0;
     border-bottom: 1px solid var(--border-color);
+    display: flex;
+    align-items: flex-start;
+    gap: 14px;
 }
 
 .listItem:last-child {
     border-bottom: none;
+}
+
+.textBlock {
+    flex: 1;
+    min-width: 0;
 }
 
 .tagEyebrow {
@@ -63,4 +71,14 @@
     font-size: 11px;
     font-weight: 400;
     color: var(--text-secondary-color);
+}
+
+.thumbnail {
+    width: 80px;
+    height: 64px;
+    object-fit: cover;
+    border-radius: 3px;
+    flex-shrink: 0;
+    display: block;
+    overflow: hidden;
 }

--- a/src/style/idea-roll.module.css
+++ b/src/style/idea-roll.module.css
@@ -74,11 +74,15 @@
 }
 
 .thumbnail {
-    width: 80px;
-    height: 64px;
-    object-fit: cover;
-    border-radius: 3px;
+    width: 88px;
+    height: 56px;
+    border-radius: 28px;
+    overflow: hidden;
     flex-shrink: 0;
     display: block;
-    overflow: hidden;
+    box-sizing: border-box;
+    box-shadow:
+        0 0 0 1.5px rgba(255, 110, 0, 0.4),
+        0 0 10px 2px rgba(255, 110, 0, 0.2),
+        0 2px 8px rgba(0, 0, 0, 0.15);
 }

--- a/src/style/idea-roll.module.css
+++ b/src/style/idea-roll.module.css
@@ -82,7 +82,9 @@
     display: block;
     box-sizing: border-box;
     box-shadow:
-        0 0 0 1.5px rgba(255, 110, 0, 0.4),
-        0 0 10px 2px rgba(255, 110, 0, 0.2),
+        0 0 0 1.5px
+            color-mix(in srgb, var(--thumbnail-border-color) 40%, transparent),
+        0 0 10px 2px
+            color-mix(in srgb, var(--thumbnail-border-color) 20%, transparent),
         0 2px 8px rgba(0, 0, 0, 0.15);
 }


### PR DESCRIPTION
## Problem 
the index page is all text 

## Review time
small: one new component with styles 

## Summary

- Extends the `IdeaRoll` GraphQL query to fetch the first figure from each idea's `preliminaryFindings.figures`
- Renders a pill-shaped thumbnail (88×56px, zoomed in 20%) on the right side of each list item when an image is available — supports both local `imageFile` figures (via GatsbyImage) and external `imageLink` figures (plain `<img>`)
- Styling: stadium/pill mask with a soft orange (`--ALLEN_ORANGE`) glow via `box-shadow`; posts without images are unchanged
- Extracts thumbnail rendering into a standalone `FigureThumbnail` component so future image sources only require changes in one place


## Example screenshot 

<img width="2614" height="1306" alt="Screenshot 2026-06-02 at 3 18 41 PM" src="https://github.com/user-attachments/assets/f3a8e83f-2c6a-4212-89fd-40b66875c168" />

## Test Plan

- [x] Verify ideas with a local `imageFile` figure show a pill thumbnail with orange glow
- [x] Verify ideas with an external `imageLink` figure show the same treatment
- [x] Verify ideas with no figures look identical to before (no empty box, full-width text)
- [x] Verify `yarn typeCheck` and `yarn test` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)