### PR TITLE
Enable editorial workflow in Decap CMS

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,3 +1,5 @@
+publish_mode: editorial_workflow
+
 backend:
     name: git-gateway
     branch: main
@@ -179,7 +181,6 @@ collections:
                 hint: "Select other resources from the Resources collection, if missing, please add to the Resources collection and then finish editing this entry.",
             }
           - {
-
                 label: "Related Ideas",
                 name: "related_ideas",
                 widget: "relation",


### PR DESCRIPTION
Problem
=======
CMS content editors can publish directly to main without any review step, bypassing the editorial process.

Solution
========
Enable `publish_mode: editorial_workflow` in the Decap CMS config so all content changes go through a draft → in review → ready to publish workflow before being merged.

## Type of change

* New feature (non-breaking change which adds functionality)

Change summary:
---------------
* Enable editorial workflow mode in static/admin/config.yml
* Remove stray blank line in Related Ideas relation widget config

Steps to Verify:
----------------
1. Open the CMS at `/admin`
2. Create or edit an idea/program entry
3. Verify the save button shows "Save draft" instead of publishing immediately
4. Verify entries move through draft → in review → ready states before publishing

Keyfiles:
-----------------------
1. static/admin/config.yml