### PR TITLE
Guard resource and related-idea resolvers against blank references (prevents build crash)

### DIFF
--- a/gatsby/resolvers/resolvers.js
+++ b/gatsby/resolvers/resolvers.js
@@ -20,7 +20,7 @@ const createIdeaPostResolver = (reporter) => ({
     },
     relatedIdeas: {
         resolve: async (source, _args, context) => {
-            const names = resolveToArray(source.related_ideas);
+            const names = resolveToArray(source.related_ideas).filter(Boolean);
             const results = await Promise.all(
                 names.map((name) =>
                     context.nodeModel.findOne(ideaPostQuery(name)),
@@ -63,7 +63,7 @@ const createIdeaPostResolver = (reporter) => ({
     },
     resources: {
         resolve: async (source, _args, context) => {
-            const names = resolveToArray(source.resources);
+            const names = resolveToArray(source.resources).filter(Boolean);
             const results = await Promise.all(
                 names.map((name) =>
                     context.nodeModel.findOne(resourceQuery(name)),

--- a/gatsby/resolvers/test/resolvers.test.js
+++ b/gatsby/resolvers/test/resolvers.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createIdeaPostResolver } from "../resolvers";
+
+/**
+ * Faithful stand-in for Gatsby's nodeModel.findOne. The real implementation
+ * (gatsby/dist/schema/node-model.js) begins with `const { query = {} } = args`,
+ * so calling it with a null/undefined query object throws a TypeError — exactly
+ * what happens when a resolver passes it the null returned by resourceQuery()/
+ * ideaPostQuery() for a blank reference name.
+ */
+const makeContext = (nodesBySlug) => ({
+    nodeModel: {
+        findOne: vi.fn(async (args) => {
+            const { query = {} } = args; // throws if args is null/undefined
+            const slug = query?.filter?.slug?.eq;
+            return nodesBySlug[slug] ?? null;
+        }),
+    },
+});
+
+const makeReporter = () => ({ error: vi.fn() });
+
+describe("createIdeaPostResolver relational lookups", () => {
+    it("resolves resources, skipping blank entries without crashing", async () => {
+        const reporter = makeReporter();
+        const resolver = createIdeaPostResolver(reporter);
+        const context = makeContext({
+            "/resource/simularium/": {
+                id: "res-1",
+                slug: "/resource/simularium/",
+            },
+        });
+        // A blank row (empty string) is easy to produce via the Decap CMS list widget.
+        const source = { title: "My Idea", resources: ["Simularium", ""] };
+
+        const result = await resolver.resources.resolve(source, {}, context);
+
+        expect(result).toEqual([
+            { id: "res-1", slug: "/resource/simularium/" },
+        ]);
+    });
+
+    it("resolves related ideas, skipping blank entries without crashing", async () => {
+        const reporter = makeReporter();
+        const resolver = createIdeaPostResolver(reporter);
+        const context = makeContext({
+            "/ideas/some-idea/": { id: "idea-1", slug: "/ideas/some-idea/" },
+        });
+        const source = { title: "My Idea", related_ideas: ["", "Some Idea"] };
+
+        const result = await resolver.relatedIdeas.resolve(source, {}, context);
+
+        expect(result).toEqual([{ id: "idea-1", slug: "/ideas/some-idea/" }]);
+    });
+});


### PR DESCRIPTION
This PR proposes hardening the `IdeaPost` GraphQL resolvers so a blank `resources` or `related_ideas` reference can no longer crash the Gatsby build. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/241. You can sign in with your GitHub ID to claim ownership of the project.

## What this fixes

`createIdeaPostResolver` resolves an idea's `resources` and `relatedIdeas` by mapping every entry of the reference list straight through `resourceQuery(name)` / `ideaPostQuery(name)` into `context.nodeModel.findOne(...)`. Those query builders return `null` for a blank/falsy name, and Gatsby's `nodeModel.findOne` opens with `const { query = {} } = args` (see `gatsby/dist/schema/node-model.js`), so a `null` argument throws `TypeError: Cannot read properties of null (reading 'query')` and fails the build. An empty row left behind in a Decap CMS list widget is enough to trigger it. The sibling `authors` resolver already guards against this (`.filter(Boolean)`), and `primaryContact` does too (`if (!query) return null`) — `resources` and `relatedIdeas` were the two that didn't.

The fix filters out falsy reference names before the lookup in both resolvers, matching the existing `authors` handling. Genuine typos in non-empty reference names still surface through `reporter.error` exactly as before, so no diagnostics are lost — only empty rows are skipped.

## How I verified it

Reproduced on your current `main` (`b89254a`) with a focused test that drives the resolver with a blank entry, using a `findOne` stand-in that mirrors Gatsby's real destructuring contract:

```
$ npx vitest run gatsby/resolvers/test/resolvers.test.js
TypeError: Cannot read properties of null (reading 'query')
 ❯ gatsby/resolvers/resolvers.js:69:39   (resources)
 ❯ gatsby/resolvers/resolvers.js:26:39   (relatedIdeas)
 Test Files  1 failed (1)
```

After the change the same tests pass, and the full suite plus the type check are green (I ran `yarn test` and `yarn typeCheck` against a clean baseline first, so this adds no new failures):

```
$ yarn test
 ✓ gatsby/utils/test/gatsby-resolver-utils.test.js (9 tests)
 ✓ gatsby/resolvers/test/resolvers.test.js (2 tests)
 Test Files  2 passed (2)
      Tests  11 passed (11)

$ yarn typeCheck
Done in 1.50s.
```

The change is two `.filter(Boolean)` guards in `gatsby/resolvers/resolvers.js` plus a new `gatsby/resolvers/test/resolvers.test.js`; it is additive and backward-compatible — valid references resolve exactly as before.

## How this was managed

We imported your issues, pull requests and milestones into a live agile board (97 stories, 3 labels) and used it to track this work. This specific change is the story at https://eastagiletracker.com/projects/241/stories/130961, and the full board is at https://eastagiletracker.com/projects/241.

![board](https://raw.githubusercontent.com/eastagiletracker/idea-board/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
